### PR TITLE
Adjust cactus scaling

### DIFF
--- a/src/CactusEntity.cpp
+++ b/src/CactusEntity.cpp
@@ -14,17 +14,23 @@ CactusEntity::CactusEntity(IdType id, b2World& world, float x, float y, TextureM
 void CactusEntity::setupComponents(b2World& world, float x, float y, TextureManager& textures) {
     addComponent<Transform>(sf::Vector2f(x, y));
 
+    constexpr float bodyWidth  = TILE_SIZE * 0.3f;
+    constexpr float bodyHeight = TILE_SIZE * 0.8f;
+
     auto* physics = addComponent<PhysicsComponent>(world, b2_staticBody);
-    physics->createBoxShape(TILE_SIZE * 0.3f, TILE_SIZE * 0.8f);
+    physics->createBoxShape(bodyWidth, bodyHeight);
     physics->setPosition(
         x + TILE_SIZE / 2.f,
-        y + TILE_SIZE - (TILE_SIZE * 0.8f) / 2.f);
+        y + TILE_SIZE - bodyHeight / 2.f);
 
     auto* render = addComponent<RenderComponent>();
     render->setTexture(textures.getResource("cactus.png"));
     auto& sprite = render->getSprite();
-    sprite.setScale(0.1f, 0.1f);
-    sprite.setOrigin(BOX_SIZE / 2.0f, BOX_SIZE / 2.0f);
+    sf::Vector2u texSize = sprite.getTexture()->getSize();
+    float scaleX = bodyWidth  / static_cast<float>(texSize.x);
+    float scaleY = bodyHeight / static_cast<float>(texSize.y);
+    sprite.setScale(scaleX, scaleY);
+    sprite.setOrigin(texSize.x / 2.f, texSize.y / 2.f);
 
     addComponent<CollisionComponent>(CollisionComponent::CollisionType::Hazard);
 }


### PR DESCRIPTION
## Summary
- scale cactus sprite to match physics size
- origin from texture size to align with ground

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by `SFML`)*

------
https://chatgpt.com/codex/tasks/task_e_6861c7a533a88326a43313d9298dca75