### PR TITLE
Enable pushing of box entity

### DIFF
--- a/include/PhysicsComponent.h
+++ b/include/PhysicsComponent.h
@@ -32,7 +32,10 @@ public:
 
     // Configure physics body
     void createCircleShape(float radius);
-    void createBoxShape(float width, float height);
+    void createBoxShape(float width, float height,
+                        float density = 1.0f,
+                        float friction = 0.3f,
+                        float restitution = 0.1f);
 
 private:
     b2Body* m_body = nullptr;

--- a/src/BoxEntity.cpp
+++ b/src/BoxEntity.cpp
@@ -12,11 +12,15 @@ BoxEntity::BoxEntity(IdType id, b2World& world, float x, float y, TextureManager
 }
 
 void BoxEntity::setupComponents(b2World& world, float x, float y, TextureManager& textures) {
-    addComponent<Transform>(sf::Vector2f(x, y));
+    addComponent<Transform>(sf::Vector2f(x + BOX_SIZE / 2.f,
+                                         y + TILE_SIZE - BOX_SIZE / 2.f));
 
     // Dynamic body so it can be pushed
     auto* physics = addComponent<PhysicsComponent>(world, b2_dynamicBody);
-    physics->createBoxShape(BOX_SIZE, BOX_SIZE);
+    physics->createBoxShape(BOX_SIZE, BOX_SIZE,
+                            BOX_DENSITY,
+                            BOX_FRICTION,
+                            BOX_RESTITUTION);
     physics->setPosition(x + BOX_SIZE / 2.f,
                          y + TILE_SIZE - BOX_SIZE / 2.f);
 
@@ -30,7 +34,11 @@ void BoxEntity::setupComponents(b2World& world, float x, float y, TextureManager
     auto* render = addComponent<RenderComponent>();
     render->setTexture(textures.getResource("wooden_box.png"));
     auto& sprite = render->getSprite();
-    sprite.setOrigin(BOX_SIZE / 2.0f, BOX_SIZE / 2.0f);
+    sf::Vector2u texSize = sprite.getTexture()->getSize();
+    float scaleX = BOX_SIZE / static_cast<float>(texSize.x);
+    float scaleY = BOX_SIZE / static_cast<float>(texSize.y);
+    sprite.setScale(scaleX, scaleY);
+    sprite.setOrigin(texSize.x / 2.f, texSize.y / 2.f);
 
     addComponent<CollisionComponent>(CollisionComponent::CollisionType::Obstacle);
 }

--- a/src/PhysicsComponent.cpp
+++ b/src/PhysicsComponent.cpp
@@ -108,7 +108,10 @@ void PhysicsComponent::createCircleShape(float radius) {
     m_body->CreateFixture(&fixtureDef);
 }
 
-void PhysicsComponent::createBoxShape(float width, float height) {
+void PhysicsComponent::createBoxShape(float width, float height,
+                                      float density,
+                                      float friction,
+                                      float restitution) {
     if (!m_body) return;
 
     // Remove existing fixtures
@@ -126,9 +129,9 @@ void PhysicsComponent::createBoxShape(float width, float height) {
     // Create fixture
     b2FixtureDef fixtureDef;
     fixtureDef.shape = &box;
-    fixtureDef.density = 1.0f;
-    fixtureDef.friction = 0.3f;
-    fixtureDef.restitution = 0.1f;
+    fixtureDef.density = density;
+    fixtureDef.friction = friction;
+    fixtureDef.restitution = restitution;
 
     m_body->CreateFixture(&fixtureDef);
 }


### PR DESCRIPTION
## Summary
- allow `PhysicsComponent::createBoxShape` to customize fixture parameters
- place the box entity at its physics position and scale the sprite
- use box constants when creating fixtures

## Testing
- `cmake -B build -S .` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6861ce33cba88326adb84cd8e22cd564