### PR TITLE
Update SFML path to local directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ add_subdirectory (external/box2d/src)
 
 include (cmake/Zip.cmake)
 
-set (SFML_LOCATION "C:/SFML/SFML-2.6.1")
-set (SFML_DIR "${SFML_LOCATION}/lib/cmake/SFML")
+set(SFML_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/external/SFML/SFML-2.6.1")
+set(SFML_DIR "${SFML_LOCATION}/lib/cmake/SFML")
 
 find_package (SFML 2.6 COMPONENTS graphics REQUIRED)
 

--- a/cmake/SFML.cmake
+++ b/cmake/SFML.cmake
@@ -1,6 +1,9 @@
 # Copy SFML-related DLLs to the target folder
 
-configure_file ("${SFML_LOCATION}/bin/openal32.dll" ${CMAKE_BINARY_DIR} COPYONLY)
+
+if (WIN32)
+    configure_file("${SFML_LOCATION}/bin/openal32.dll" ${CMAKE_BINARY_DIR} COPYONLY)
+endif()
 
 add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${CMAKE_PROJECT_NAME}> $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>


### PR DESCRIPTION
## Summary
- use the SFML copy from `external/` instead of hard coded Windows path
- only copy OpenAL DLL on Windows platforms

## Testing
- `cmake -S . -B build` *(fails: missing `sfml-system-d-2.dll`)*

------
https://chatgpt.com/codex/tasks/task_e_6861d9df53b483268f0e2554072fbce2