### PR TITLE
Implement projectile shooting on key press

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -16,6 +16,10 @@ constexpr float WINDOW_HEIGHT = 900.f;
 constexpr float ENEMY_WIDTH = 1.0f;
 constexpr float ENEMY_HEIGHT = 1.0f;
 
+constexpr float PROJECTILE_SPEED = 10.f;
+constexpr float PROJECTILE_RADIUS = 0.1f;
+constexpr float PROJECTILE_LIFETIME = 2.f;
+
 static constexpr float BOX_DENSITY = 0.2f;      // كثافة 
 static constexpr float BOX_FRICTION = 0.4f;     // احتكاك 
 static constexpr float BOX_RESTITUTION = 0.05f; // ارتداد 

--- a/include/PhysicsComponent.h
+++ b/include/PhysicsComponent.h
@@ -29,6 +29,8 @@ public:
     // Box2D body access
     b2Body* getBody() { return m_body; }
     const b2Body* getBody() const { return m_body; }
+    b2World& getWorld() { return m_world; }
+    const b2World& getWorld() const { return m_world; }
 
     // Configure physics body
     void createCircleShape(float radius);

--- a/include/PlayerEntity.h
+++ b/include/PlayerEntity.h
@@ -8,6 +8,7 @@
 #include "InputService.h"
 
 class PlayerState;
+class GameSession;
 
 /**
  * PlayerEntity - Enhanced with State Pattern
@@ -46,6 +47,9 @@ public:
     bool isOnGround() const;
     TextureManager& getTextures() { return m_textures; }
 
+    static void setGameSession(GameSession* session) { s_gameSession = session; }
+    static GameSession* getGameSession() { return s_gameSession; }
+
 private:
     void setupComponents(b2World& world, float x, float y, TextureManager& textures);
     void updateVisuals();
@@ -60,4 +64,6 @@ private:
 
     // Ground detection
     int m_groundContacts = 0;
+
+    static GameSession* s_gameSession;
 };

--- a/include/ProjectileEntity.h
+++ b/include/ProjectileEntity.h
@@ -3,13 +3,18 @@
 #include "Entity.h"
 #include <Box2D/Box2D.h>
 #include "ResourceManager.h"
+#include "Constants.h"
 
 class ProjectileEntity : public Entity {
 public:
     ProjectileEntity(IdType id, b2World& world, float x, float y,
         float dirX, float dirY, TextureManager& textures);
 
+    void update(float dt) override;
+
 private:
     void setupComponents(b2World& world, float x, float y,
         float dirX, float dirY, TextureManager& textures);
+
+    float m_lifetime = PROJECTILE_LIFETIME;
 };

--- a/src/GameSession.cpp
+++ b/src/GameSession.cpp
@@ -129,9 +129,10 @@ void GameSession::spawnEntity(std::unique_ptr<Entity> entity) {
         Entity* ptr = entity.get();  // Get pointer before moving
         m_entityManager.addEntity(std::move(entity));
 
-        // If it's a player, store reference
+        // If it's a player, store reference and allow it to spawn entities
         if (auto* player = dynamic_cast<PlayerEntity*>(ptr)) {
             m_player = player;
+            PlayerEntity::setGameSession(this);
         }
     }
 }

--- a/src/PlayerEntity.cpp
+++ b/src/PlayerEntity.cpp
@@ -12,8 +12,15 @@
 #include "BoostedState.h"
 #include "EventSystem.h"
 #include "GameEvents.h"
+#include "ProjectileEntity.h"
+#include "GameSession.h"
+#include "EntityManager.h"
 #include <iostream>
 #include <cmath>
+
+extern int g_nextEntityId;
+
+GameSession* PlayerEntity::s_gameSession = nullptr;
 
 PlayerEntity::PlayerEntity(IdType id, b2World& world, float x, float y, TextureManager& textures)
     : Entity(id)
@@ -118,8 +125,21 @@ void PlayerEntity::moveRight() {
 }
 
 void PlayerEntity::shoot() {
-    // TODO: Create projectile entity and add to EntityManager
-    std::cout << "Player shoot (TODO: implement projectile creation)" << std::endl;
+    if (!s_gameSession) return;
+
+    auto* physics = getComponent<PhysicsComponent>();
+    if (!physics) return;
+
+    sf::Vector2f pos = physics->getPosition();
+
+    float dirX = 1.0f;
+    float dirY = 0.0f;
+
+    auto projectile = std::make_unique<ProjectileEntity>(
+        g_nextEntityId++, physics->getWorld(), pos.x + PLAYER_RADIUS * PPM, pos.y,
+        dirX, dirY, m_textures);
+
+    s_gameSession->spawnEntity(std::move(projectile));
 }
 
 void PlayerEntity::addScore(int points) {

--- a/src/ProjectileEntity.cpp
+++ b/src/ProjectileEntity.cpp
@@ -1,0 +1,43 @@
+#include "ProjectileEntity.h"
+#include "Transform.h"
+#include "PhysicsComponent.h"
+#include "RenderComponent.h"
+#include "CollisionComponent.h"
+#include "Constants.h"
+
+ProjectileEntity::ProjectileEntity(IdType id, b2World& world, float x, float y,
+                                   float dirX, float dirY, TextureManager& textures)
+    : Entity(id) {
+    setupComponents(world, x, y, dirX, dirY, textures);
+}
+
+void ProjectileEntity::setupComponents(b2World& world, float x, float y,
+                                       float dirX, float dirY, TextureManager& textures) {
+    addComponent<Transform>(sf::Vector2f(x, y));
+
+    auto* physics = addComponent<PhysicsComponent>(world, b2_dynamicBody);
+    physics->createCircleShape(PROJECTILE_RADIUS * PPM);
+    physics->setPosition(x, y);
+    physics->setVelocity(dirX * PROJECTILE_SPEED, dirY * PROJECTILE_SPEED);
+    if (auto* body = physics->getBody()) {
+        body->SetBullet(true);
+        body->SetGravityScale(0.f);
+    }
+
+    auto* render = addComponent<RenderComponent>();
+    render->setTexture(textures.getResource("Bullet.png"));
+    auto& sprite = render->getSprite();
+    sprite.setScale(0.05f, 0.05f);
+    auto bounds = sprite.getLocalBounds();
+    sprite.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+
+    addComponent<CollisionComponent>(CollisionComponent::CollisionType::Projectile);
+}
+
+void ProjectileEntity::update(float dt) {
+    Entity::update(dt);
+    m_lifetime -= dt;
+    if (m_lifetime <= 0.f) {
+        setActive(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add projectile constants
- expose `b2World` from `PhysicsComponent`
- allow `PlayerEntity` to access `GameSession`
- implement `ProjectileEntity` with lifetime logic
- spawn projectiles when the player presses `C`

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6861ef29fe7c83268b9cc8f942650425