### PR TITLE
Fix enemy speed scaling

### DIFF
--- a/src/FollowPlayerStrategy.cpp
+++ b/src/FollowPlayerStrategy.cpp
@@ -4,6 +4,7 @@
 #include "PlayerEntity.h"
 #include "Transform.h"
 #include "PhysicsComponent.h"
+#include "Constants.h"
 #include <iostream>
 #include <cmath>
 
@@ -47,7 +48,8 @@ void FollowPlayerStrategy::update(Entity& entity, float dt, PlayerEntity* player
 
         // Move towards player horizontally
         sf::Vector2f velocity = physics->getVelocity();
-        physics->setVelocity(direction.x * m_speed, velocity.y);
+        // Convert speed from pixels/sec to Box2D meters/sec
+        physics->setVelocity(direction.x * (m_speed / PPM), velocity.y);
 
         if (frameCount % 60 == 0) {
             std::cout << "[FOLLOW] Chasing player! Direction: " << direction.x

--- a/src/GameSession.cpp
+++ b/src/GameSession.cpp
@@ -105,7 +105,8 @@ void GameSession::loadLevel(const std::string& levelPath) {
 
                             // Give it a small initial velocity
                             if (enemy->getEnemyType() == EnemyEntity::EnemyType::Square) {
-                                physics->setVelocity(50.0f, 0.0f); // Start moving right
+                                // Convert speed to meters/sec for Box2D
+                                physics->setVelocity(50.0f / PPM, 0.0f); // Start moving right
                                 std::cout << "[GameSession] Gave initial velocity to Square enemy "
                                     << enemy->getId() << std::endl;
                             }

--- a/src/GuardStrategy.cpp
+++ b/src/GuardStrategy.cpp
@@ -6,6 +6,7 @@
 #include "PhysicsComponent.h"
 #include "EventSystem.h"
 #include "GameEvents.h"
+#include "Constants.h"
 #include <iostream>
 
 GuardStrategy::GuardStrategy(float guardRadius, float attackRange)
@@ -53,12 +54,13 @@ void GuardStrategy::update(Entity& entity, float dt, PlayerEntity* player) {
     // If player is within guard radius, move towards them
     else if (distanceToPlayer <= m_guardRadius) {
         sf::Vector2f direction = getDirectionToPlayer(entityPos, playerPos);
-        physics->setVelocity(direction.x * 80.0f, physics->getVelocity().y);
+        // Convert speeds to Box2D meters/sec
+        physics->setVelocity(direction.x * (80.0f / PPM), physics->getVelocity().y);
     }
     // Otherwise, return to guard position
     else if (distanceToGuardPos > 10.0f) {
         sf::Vector2f direction = getDirectionToPlayer(entityPos, m_guardPosition);
-        physics->setVelocity(direction.x * 50.0f, physics->getVelocity().y);
+        physics->setVelocity(direction.x * (50.0f / PPM), physics->getVelocity().y);
     }
     else {
         // At guard position, stand still

--- a/src/PatrolStrategy.cpp
+++ b/src/PatrolStrategy.cpp
@@ -3,6 +3,7 @@
 #include "Entity.h"
 #include "Transform.h"
 #include "PhysicsComponent.h"
+#include "Constants.h"
 #include <iostream>
 #include <cmath>
 
@@ -41,7 +42,8 @@ void PatrolStrategy::update(Entity& entity, float dt, PlayerEntity* player) {
 
     // Move in current direction
     sf::Vector2f velocity = physics->getVelocity();
-    physics->setVelocity(m_direction * m_speed, velocity.y);
+    // Convert speed from pixels/sec to Box2D meters/sec
+    physics->setVelocity(m_direction * (m_speed / PPM), velocity.y);
 
     // Debug output every 60 frames (about once per second)
     static int frameCount = 0;


### PR DESCRIPTION
## Summary
- ensure patrol and follow speeds use pixel units
- convert guard and initial enemy speeds to meters per second

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6862fff107ec83269841dbdcb914a698