### PR TITLE
Fix sprite alignment for grounded entities

### DIFF
--- a/src/FlagEntity.cpp
+++ b/src/FlagEntity.cpp
@@ -12,15 +12,21 @@ FlagEntity::FlagEntity(IdType id, b2World& world, float x, float y, TextureManag
 }
 
 void FlagEntity::setupComponents(b2World& world, float x, float y, TextureManager& textures) {
-    addComponent<Transform>(sf::Vector2f(x, y));
+    float centerX = x + TILE_SIZE / 2.f;
+    float centerY = y + TILE_SIZE / 2.f;
+
+    addComponent<Transform>(sf::Vector2f(centerX, centerY));
 
     auto* physics = addComponent<PhysicsComponent>(world, b2_staticBody);
     physics->createBoxShape(TILE_SIZE / 2.f, TILE_SIZE);
-    physics->setPosition(x + TILE_SIZE / 2.f, y + TILE_SIZE / 2.f);
+    physics->setPosition(centerX, centerY);
 
     auto* render = addComponent<RenderComponent>();
     render->setTexture(textures.getResource("redflag.png"));
-    render->getSprite().setPosition(x, y);
+    auto& sprite = render->getSprite();
+    auto bounds = sprite.getLocalBounds();
+    sprite.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+    sprite.setPosition(centerX, centerY);
 
     addComponent<CollisionComponent>(CollisionComponent::CollisionType::Collectible);
 }

--- a/src/GroundEntity.cpp
+++ b/src/GroundEntity.cpp
@@ -15,20 +15,28 @@ GroundEntity::GroundEntity(IdType id, TileType type, b2World& world, float x, fl
 
 void GroundEntity::setupComponents(TileType type, b2World& world, float x, float y, TextureManager& textures) {
     float heightOffset = (type == TileType::Edge) ? EDGE_HEIGHT_OFFSET : 0.f;
-    // Add transform
-    addComponent<Transform>(sf::Vector2f(x, y - heightOffset));
+    // Use the tile centre as the logical position so physics and rendering
+    // remain in sync when the PhysicsComponent updates the Transform.
+    float centerX = x + TILE_SIZE / 2.f;
+    float centerY = y + TILE_SIZE / 2.f - heightOffset;
+
+    // Add transform at the centre of the tile
+    addComponent<Transform>(sf::Vector2f(centerX, centerY));
 
     // Add physics (static body for ground)
     auto* physics = addComponent<PhysicsComponent>(world, b2_staticBody);
     physics->createBoxShape(TILE_SIZE, TILE_SIZE);
-    physics->setPosition(x + TILE_SIZE / 2.f, y + TILE_SIZE / 2.f - heightOffset);
+    physics->setPosition(centerX, centerY);
 
     // Add rendering
     auto* render = addComponent<RenderComponent>();
     std::string textureName = getTextureNameForType(type);
     render->setTexture(textures.getResource(textureName));
     auto& sprite = render->getSprite();
-    sprite.setPosition(x, y - heightOffset);
+    // Centre the sprite so that it matches the transform location
+    auto bounds = sprite.getLocalBounds();
+    sprite.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+    sprite.setPosition(centerX, centerY);
 
     // Add collision
     addComponent<CollisionComponent>(CollisionComponent::CollisionType::Ground);

--- a/src/SeaEntity.cpp
+++ b/src/SeaEntity.cpp
@@ -12,15 +12,22 @@ SeaEntity::SeaEntity(IdType id, b2World& world, float x, float y, TextureManager
 }
 
 void SeaEntity::setupComponents(b2World& world, float x, float y, TextureManager& textures) {
-    addComponent<Transform>(sf::Vector2f(x, y));
+    // Position is stored at the centre so physics and rendering stay aligned
+    float centerX = x + TILE_SIZE / 2.f;
+    float centerY = y + TILE_SIZE / 2.f;
+
+    addComponent<Transform>(sf::Vector2f(centerX, centerY));
 
     auto* physics = addComponent<PhysicsComponent>(world, b2_staticBody);
     physics->createBoxShape(TILE_SIZE, TILE_SIZE);
-    physics->setPosition(x + TILE_SIZE / 2.f, y + TILE_SIZE / 2.f);
+    physics->setPosition(centerX, centerY);
 
     auto* render = addComponent<RenderComponent>();
     render->setTexture(textures.getResource("Sea.png"));
-    render->getSprite().setPosition(x, y);
+    auto& sprite = render->getSprite();
+    auto bounds = sprite.getLocalBounds();
+    sprite.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+    sprite.setPosition(centerX, centerY);
 
     addComponent<CollisionComponent>(CollisionComponent::CollisionType::Hazard);
 }


### PR DESCRIPTION
## Summary
- adjust GroundEntity transform origin and sprite position
- correct SeaEntity and FlagEntity setup so sprite/physics origins match

## Testing
- `cmake ..` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_686303ef80b483268511823dcfbedadc