### PR TITLE
Fix surprise box behavior and coin tracking

### DIFF
--- a/include/SurpriseBoxManager.h
+++ b/include/SurpriseBoxManager.h
@@ -17,7 +17,9 @@ class PlayerEntity;
 
 class SurpriseBoxManager {
 public:
-    static constexpr int COINS_FOR_SURPRISE = 5;
+    // Number of coins required before triggering the surprise box
+    // The design calls for a reward every ten coins collected
+    static constexpr int COINS_FOR_SURPRISE = 10;
 
     SurpriseBoxManager(TextureManager& textures, sf::RenderWindow& window);
     ~SurpriseBoxManager() = default;

--- a/src/SurpriseBoxManager.cpp
+++ b/src/SurpriseBoxManager.cpp
@@ -23,10 +23,12 @@ SurpriseBoxManager::SurpriseBoxManager(TextureManager& textures, sf::RenderWindo
     // Create surprise box screen
     m_surpriseScreen = std::make_unique<SurpriseBoxScreen>(window, textures);
 
-    // Subscribe to coin collection events
-    EventSystem::getInstance().subscribe<CoinCollectedEvent>(
-        [this](const CoinCollectedEvent& event) {
-            this->onCoinCollected();
+    // Subscribe to item collection events and count coins
+    EventSystem::getInstance().subscribe<ItemCollectedEvent>(
+        [this](const ItemCollectedEvent& event) {
+            if (event.type == ItemCollectedEvent::ItemType::Coin) {
+                this->onCoinCollected();
+            }
         }
     );
 }
@@ -64,9 +66,10 @@ void SurpriseBoxManager::triggerSurprise() {
         return;
     }
 
-    // Calculate spawn position (to the right of player)
+    // Calculate spawn position - slightly to the right of the player and on
+    // the same vertical level so the gift appears on the ground
     sf::Vector2f playerPos = playerTransform->getPosition();
-    sf::Vector2f spawnPos = playerPos + sf::Vector2f(150.0f, -50.0f);
+    sf::Vector2f spawnPos = playerPos + sf::Vector2f(50.0f, 0.0f);
 
     // Spawn the selected gift
     spawnGiftEntity(selectedGift, spawnPos);

--- a/src/SurpriseBoxScreen.cpp
+++ b/src/SurpriseBoxScreen.cpp
@@ -43,11 +43,14 @@ SurpriseBoxScreen::SurpriseBoxScreen(sf::RenderWindow& window, TextureManagerTyp
 
 SurpriseGiftType SurpriseBoxScreen::showSurpriseBox() {
     m_isRunning = true;
-    m_boxOpened = false;
+    m_boxOpened = true;             // open immediately
     m_animationTimer = 0.0f;
     m_boxScale = 0.0f;
     m_particles.clear();
     m_giftImageLoaded = false;
+    // Select the gift right away and create opening particles
+    m_selectedGift = getRandomGiftType();
+    createParticles();
 
     sf::Clock clock;
 
@@ -68,14 +71,14 @@ void SurpriseBoxScreen::handleEvents() {
             m_window.close();
             m_isRunning = false;
         }
-        if (event.type == sf::Event::KeyPressed) {
-            if (event.key.code == sf::Keyboard::Space && !m_boxOpened) {
+        if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Space) {
+            // Space acts as a skip/continue key once the gift is revealed
+            if (!m_boxOpened) {
                 m_boxOpened = true;
                 m_animationTimer = 0.0f;
                 createParticles();
                 m_selectedGift = getRandomGiftType();
-            }
-            else if (event.key.code == sf::Keyboard::Enter && m_boxOpened) {
+            } else {
                 m_isRunning = false;
             }
         }


### PR DESCRIPTION
## Summary
- trigger surprise boxes after 10 coins
- listen to `ItemCollectedEvent` for coins
- spawn gifts near the player on the ground
- open surprise box screen automatically and allow skipping with space

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68630d725b6083268c1b0a669c4ac9c3