### PR TITLE
Fix SurpriseBox screen trigger and spawn

### DIFF
--- a/include/SurpriseBoxManager.h
+++ b/include/SurpriseBoxManager.h
@@ -17,7 +17,8 @@ class PlayerEntity;
 
 class SurpriseBoxManager {
 public:
-    static constexpr int COINS_FOR_SURPRISE = 5;
+    // Number of coins required before showing the surprise box
+    static constexpr int COINS_FOR_SURPRISE = 10;
 
     SurpriseBoxManager(TextureManager& textures, sf::RenderWindow& window);
     ~SurpriseBoxManager() = default;

--- a/src/SurpriseBoxManager.cpp
+++ b/src/SurpriseBoxManager.cpp
@@ -23,10 +23,12 @@ SurpriseBoxManager::SurpriseBoxManager(TextureManager& textures, sf::RenderWindo
     // Create surprise box screen
     m_surpriseScreen = std::make_unique<SurpriseBoxScreen>(window, textures);
 
-    // Subscribe to coin collection events
-    EventSystem::getInstance().subscribe<CoinCollectedEvent>(
-        [this](const CoinCollectedEvent& event) {
-            this->onCoinCollected();
+    // Subscribe to coin collection events via ItemCollectedEvent
+    EventSystem::getInstance().subscribe<ItemCollectedEvent>(
+        [this](const ItemCollectedEvent& event) {
+            if (event.type == ItemCollectedEvent::ItemType::Coin) {
+                this->onCoinCollected();
+            }
         }
     );
 }
@@ -66,7 +68,8 @@ void SurpriseBoxManager::triggerSurprise() {
 
     // Calculate spawn position (to the right of player)
     sf::Vector2f playerPos = playerTransform->getPosition();
-    sf::Vector2f spawnPos = playerPos + sf::Vector2f(150.0f, -50.0f);
+    // Spawn the gift slightly to the right of the player at ground height
+    sf::Vector2f spawnPos = playerPos + sf::Vector2f(150.0f, 0.0f);
 
     // Spawn the selected gift
     spawnGiftEntity(selectedGift, spawnPos);

--- a/src/SurpriseBoxScreen.cpp
+++ b/src/SurpriseBoxScreen.cpp
@@ -43,11 +43,14 @@ SurpriseBoxScreen::SurpriseBoxScreen(sf::RenderWindow& window, TextureManagerTyp
 
 SurpriseGiftType SurpriseBoxScreen::showSurpriseBox() {
     m_isRunning = true;
-    m_boxOpened = false;
+    // Open the box immediately and choose a gift
+    m_boxOpened = true;
+    m_selectedGift = getRandomGiftType();
     m_animationTimer = 0.0f;
     m_boxScale = 0.0f;
     m_particles.clear();
     m_giftImageLoaded = false;
+    createParticles();
 
     sf::Clock clock;
 
@@ -69,13 +72,8 @@ void SurpriseBoxScreen::handleEvents() {
             m_isRunning = false;
         }
         if (event.type == sf::Event::KeyPressed) {
-            if (event.key.code == sf::Keyboard::Space && !m_boxOpened) {
-                m_boxOpened = true;
-                m_animationTimer = 0.0f;
-                createParticles();
-                m_selectedGift = getRandomGiftType();
-            }
-            else if (event.key.code == sf::Keyboard::Enter && m_boxOpened) {
+            // Allow player to skip the screen
+            if (event.key.code == sf::Keyboard::Space) {
                 m_isRunning = false;
             }
         }


### PR DESCRIPTION
## Summary
- fix coin count requirement to trigger SurpriseBox
- track collected coins via `ItemCollectedEvent`
- spawn surprise gifts on ground beside the player
- open surprise box immediately and allow skipping with space

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68630ec4de9c83268fb7a0c96511323e