### PR TITLE
Add projectile shooting for player

### DIFF
--- a/include/GameSession.h
+++ b/include/GameSession.h
@@ -11,6 +11,9 @@
 
 class PlayerEntity;
 
+// Global pointer to the active game session for easy access
+extern class GameSession* g_currentSession;
+
 /**
  * GameSession - Manages the game entities and systems
  * Replaces GameWorld with component-based architecture

--- a/include/PlayerEntity.h
+++ b/include/PlayerEntity.h
@@ -54,6 +54,7 @@ private:
 
     int m_score = 0;
     TextureManager& m_textures;
+    b2World& m_world;
 
     // State Pattern
     PlayerState* m_currentState = nullptr;

--- a/src/GameCollisionSetup.cpp
+++ b/src/GameCollisionSetup.cpp
@@ -4,6 +4,7 @@
 #include "EnemyEntity.h"
 #include "GiftEntity.h"
 #include "CoinEntity.h"
+#include "ProjectileEntity.h"
 #include "EntityFactory.h"
 #include "HealthComponent.h"
 #include "PhysicsComponent.h"
@@ -162,6 +163,25 @@ void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
         [](PlayerEntity& player, FlagEntity& flag) {
             std::cout << "Level Complete! Player reached the flag!" << std::endl;
             // TODO: Trigger level complete event
+        }
+    );
+
+    // Projectile (from player) vs Enemy
+    collisionSystem.registerHandler<ProjectileEntity, EnemyEntity>(
+        [](ProjectileEntity& proj, EnemyEntity& enemy) {
+            if (!proj.isFromPlayer() || !enemy.isActive()) return;
+
+            auto* health = enemy.getComponent<HealthComponent>();
+            if (health) {
+                health->takeDamage(1);
+                if (!health->isAlive()) {
+                    enemy.setActive(false);
+                    EventSystem::getInstance().publish(
+                        EnemyKilledEvent(enemy.getId(), proj.getId()));
+                }
+            }
+
+            proj.setActive(false);
         }
     );
 }

--- a/src/GameSession.cpp
+++ b/src/GameSession.cpp
@@ -12,11 +12,19 @@
 #include <RenderComponent.h>
 #include <PhysicsComponent.h>
 
+// Global pointer to the current active session
+GameSession* g_currentSession = nullptr;
+
 GameSession::GameSession()
     : m_physicsWorld(b2Vec2(0.0f, 9.8f)) {
+    g_currentSession = this;
 }
 
-GameSession::~GameSession() = default;
+GameSession::~GameSession() {
+    if (g_currentSession == this) {
+        g_currentSession = nullptr;
+    }
+}
 
 void GameSession::initialize(TextureManager& textures, sf::RenderWindow& window) {
     m_textures = &textures;


### PR DESCRIPTION
## Summary
- add global pointer to GameSession for runtime access
- store physics world in `PlayerEntity`
- implement `PlayerEntity::shoot` to spawn `ProjectileEntity`
- register projectile vs enemy collision handler

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*
- `cmake --build build` *(fails: no `Makefile`)*

------
https://chatgpt.com/codex/tasks/task_e_686311e8a17483268c1e32df62714965