### PR TITLE
Fix missing Constants.h includes in state classes

### DIFF
--- a/src/BoostedState.cpp
+++ b/src/BoostedState.cpp
@@ -3,6 +3,7 @@
 #include "PlayerEntity.h"
 #include "PhysicsComponent.h"
 #include "RenderComponent.h"
+#include "Constants.h"
 #include <iostream>
 
 std::unique_ptr<BoostedState> BoostedState::s_instance = nullptr;

--- a/src/HeadwindState.cpp
+++ b/src/HeadwindState.cpp
@@ -3,6 +3,7 @@
 #include "PlayerEntity.h"
 #include "PhysicsComponent.h"
 #include "RenderComponent.h"
+#include "Constants.h"
 #include <iostream>
 
 std::unique_ptr<HeadwindState> HeadwindState::s_instance = nullptr;

--- a/src/MagneticState.cpp
+++ b/src/MagneticState.cpp
@@ -6,6 +6,7 @@
 #include "Transform.h"
 #include "CoinEntity.h"
 #include "GameSession.h"
+#include "Constants.h"
 #include <cmath>
 #include <iostream>
 

--- a/src/ReversedState.cpp
+++ b/src/ReversedState.cpp
@@ -3,6 +3,7 @@
 #include "PlayerEntity.h"
 #include "PhysicsComponent.h"
 #include "RenderComponent.h"
+#include "Constants.h"
 #include <cmath>
 #include <iostream>
 

--- a/src/ShieldedState.cpp
+++ b/src/ShieldedState.cpp
@@ -4,6 +4,7 @@
 #include "PhysicsComponent.h"
 #include "RenderComponent.h"
 #include "HealthComponent.h"
+#include "Constants.h"
 #include <iostream>
 
 std::unique_ptr<ShieldedState> ShieldedState::s_instance = nullptr;


### PR DESCRIPTION
## Summary
- include `Constants.h` in state source files that use player constants

## Testing
- `cmake -S . -B build` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6863401756608326b011257ab3fd7f27