### PR TITLE
Fix player cache when levels transition

### DIFF
--- a/include/GameSession.h
+++ b/include/GameSession.h
@@ -41,6 +41,9 @@ public:
     void reloadCurrentLevel();
     const std::string& getCurrentLevelName() const;
 
+    // Invalidate cached player pointer (e.g., when levels reload internally)
+    void invalidateCachedPlayer();
+
     // Other accessors
     SurpriseBoxManager* getSurpriseBoxManager() { return m_surpriseBoxManager.get(); }
     GameLevelManager& getLevelManager() { return m_levelManager; }

--- a/src/GameLevelManager.cpp
+++ b/src/GameLevelManager.cpp
@@ -2,6 +2,7 @@
 #include "EntityManager.h"
 #include "PhysicsManager.h"
 #include "ResourceManager.h"
+#include "GameSession.h"
 #include <iostream>
 #include <PlayerEntity.h>
 #include "EntityFactory.h"
@@ -36,6 +37,11 @@ bool GameLevelManager::loadLevel(const std::string& levelPath) {
         m_transitionPending = false;
         m_transitionTimer = 0.0f;
         m_needLevelSwitch = false;
+
+        // Invalidate cached player in current session since entities will be cleared
+        if (g_currentSession) {
+            g_currentSession->invalidateCachedPlayer();
+        }
 
         // إزالة أي مراجع للكائنات الحالية
         std::cout << "[GameLevelManager] Clearing current entities..." << std::endl;

--- a/src/GameSession.cpp
+++ b/src/GameSession.cpp
@@ -107,6 +107,10 @@ PlayerEntity* GameSession::getPlayer() {
     return m_player;
 }
 
+void GameSession::invalidateCachedPlayer() {
+    m_player = nullptr;
+}
+
 void GameSession::spawnEntity(std::unique_ptr<Entity> entity) {
     if (entity) {
         // Check if it's a player for caching


### PR DESCRIPTION
## Summary
- invalidate cached player when GameLevelManager clears entities
- expose `invalidateCachedPlayer` on `GameSession`
- reset cached player on load via `GameLevelManager`

## Testing
- `cmake --preset x64-Debug` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_686ff4303d80832691b0dc47216d9100