### PR TITLE
Refactor entity id generation

### DIFF
--- a/include/Core/ResourcePaths.h
+++ b/include/Core/ResourcePaths.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace ResourcePaths {
+    constexpr const char* IMAGES  = "resources/images/";
+    constexpr const char* ICONS   = "resources/icons/";
+    constexpr const char* FONTS   = "resources/fonts/";
+    constexpr const char* LEVELS  = "resources/levels/";
+    constexpr const char* SHADERS = "resources/shaders/";
+
+    constexpr const char* LEVEL1 = "level1.txt";
+    constexpr const char* LEVEL2 = "level2.txt";
+    constexpr const char* DARK_LEVEL = "dark_level.txt";
+}

--- a/include/Entities/Environment/WellEntity.h
+++ b/include/Entities/Environment/WellEntity.h
@@ -3,6 +3,7 @@
 #include "Entity.h"
 #include <Box2D/Box2D.h>
 #include "ResourceManager.h"
+#include "ResourcePaths.h"
 
 /**
  * WellEntity - Portal to dark underground levels
@@ -29,7 +30,7 @@ private:
     void updateAnimation(float dt);
 
     bool m_activated = false;
-    std::string m_targetLevel = "dark_level.txt"; // Default underground level
+    std::string m_targetLevel = ResourcePaths::DARK_LEVEL; // Default underground level
 
     // Animation variables
     float m_animationTimer = 0.0f;

--- a/include/Systems/Collision/GameCollisionSetup.h
+++ b/include/Systems/Collision/GameCollisionSetup.h
@@ -2,6 +2,7 @@
 
 #include "MultiMethodCollisionSystem.h"
 #include "ResourceManager.h"
+#include "EntityManager.h"
 #include "PlayerEntity.h"
 #include "EnemyEntity.h"
 #include "GiftEntity.h"
@@ -12,4 +13,4 @@
  * Sets up all collision handlers for the game
  */
 void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem);
-void registerGameEntities(b2World& world, TextureManager& textures);
+void registerGameEntities(b2World& world, TextureManager& textures, EntityManager& entityManager);

--- a/include/Systems/Managers/EntityManager.h
+++ b/include/Systems/Managers/EntityManager.h
@@ -38,6 +38,13 @@ public:
     void addEntity(std::unique_ptr<Entity> entity);
     void removeInactiveEntities();
 
+    /**
+     * Generate a unique identifier for a new entity.
+     * Useful when entities are created outside of EntityManager
+     * (e.g. via factories).
+     */
+    IdType generateId();
+
 
 private:
     std::unordered_map<IdType, std::unique_ptr<Entity>> m_entities;
@@ -47,8 +54,9 @@ private:
 template <typename T, typename... Args>
 T* EntityManager::createEntity(Args&&... args) {
 	static_assert(std::is_base_of<Entity, T>::value, "T must inherit from Entity");
-	auto entity = std::make_unique<T>(std::forward<Args>(args)...);
-	T* ptr = entity.get();
-	m_entities[m_nextId++] = std::move(entity);
-	return ptr;
+        auto id = generateId();
+        auto entity = std::make_unique<T>(id, std::forward<Args>(args)...);
+        T* ptr = entity.get();
+        m_entities[id] = std::move(entity);
+        return ptr;
 }

--- a/src/Entities/Enemies/FalconEnemyEntity.cpp
+++ b/src/Entities/Enemies/FalconEnemyEntity.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 #include "PlayerEntity.h"
 
-extern int g_nextEntityId;
 extern GameSession* g_currentSession;
 
 FalconEnemyEntity::FalconEnemyEntity(IdType id, b2World& world, float x, float y, TextureManager& textures)
@@ -229,7 +228,7 @@ void FalconEnemyEntity::shootProjectile() {
     try {
         // Create enemy projectile
         auto projectile = std::make_unique<ProjectileEntity>(
-            g_nextEntityId++, world,
+            g_currentSession->getEntityManager().generateId(), world,
             bulletSpawnPos.x, bulletSpawnPos.y,
             shootDir, getTextures(), false // false = enemy projectile
         );

--- a/src/Entities/Enemies/SquareEnemyEntity.cpp
+++ b/src/Entities/Enemies/SquareEnemyEntity.cpp
@@ -13,7 +13,6 @@
 #include <MovementComponent.h>
 #include <SmartEnemyEntity.h>
 
-extern int g_nextEntityId;
 extern GameSession* g_currentSession;
 
 SquareEnemyEntity::SquareEnemyEntity(IdType id, b2World& world, float x, float y,
@@ -97,7 +96,7 @@ void SquareEnemyEntity::spawnSplitEnemies(const sf::Vector2f& deathPosition) {
 
         try {
             auto smallEnemy = std::make_unique<SmartEnemyEntity>(
-                g_nextEntityId++,
+                g_currentSession->getEntityManager().generateId(),
                 world,
                 spawnPos.x - TILE_SIZE / 2.f,
                 spawnPos.y - TILE_SIZE / 2.f,

--- a/src/Entities/Environment/WellEntity.cpp
+++ b/src/Entities/Environment/WellEntity.cpp
@@ -5,6 +5,7 @@
 #include "RenderComponent.h"
 #include "CollisionComponent.h"
 #include "Constants.h"
+#include "ResourcePaths.h"
 #include <iostream>
 #include <cmath>
 
@@ -59,7 +60,7 @@ void WellEntity::onPlayerEnter() {
     // طلب تغيير المستوى بدلاً من التحميل المباشر
     std::string targetLevel = getTargetLevel();
     if (targetLevel.empty()) {
-        targetLevel = "dark_level.txt";
+        targetLevel = ResourcePaths::DARK_LEVEL;
     }
 
     requestLevelChange(targetLevel);

--- a/src/Entities/Player/PlayerWeaponSystem.cpp
+++ b/src/Entities/Player/PlayerWeaponSystem.cpp
@@ -4,8 +4,7 @@
 #include "GameSession.h"
 #include <iostream>
 
-// External references
-extern int g_nextEntityId;
+// External reference to current session for spawning projectiles
 extern GameSession* g_currentSession;
 
 PlayerWeaponSystem::PlayerWeaponSystem(PlayerEntity& player, b2World& world, TextureManager& textures)
@@ -209,7 +208,7 @@ void PlayerWeaponSystem::setWeaponType(WeaponType type) {
 void PlayerWeaponSystem::createProjectile(const sf::Vector2f& position, const sf::Vector2f& direction) {
     try {
         auto projectile = std::make_unique<ProjectileEntity>(
-            g_nextEntityId++,
+            g_currentSession->getEntityManager().generateId(),
             m_world,
             position.x,
             position.y,
@@ -229,7 +228,7 @@ void PlayerWeaponSystem::createGravityProjectile(const sf::Vector2f& position, c
     try {
         // Create a projectile with the special parameter to enable gravity
         auto projectile = std::make_unique<ProjectileEntity>(
-            g_nextEntityId++,
+            g_currentSession->getEntityManager().generateId(),
             m_world,
             position.x,
             position.y,

--- a/src/Game/GameSession.cpp
+++ b/src/Game/GameSession.cpp
@@ -10,7 +10,6 @@
 
 // Global pointer for backwards compatibility
 GameSession* g_currentSession = nullptr;
-extern int g_nextEntityId;
 
 GameSession::GameSession() {
     g_currentSession = this;
@@ -71,7 +70,7 @@ void GameSession::initialize(TextureManager& textures, sf::RenderWindow& window)
     m_eventCoordinator.initialize();
 
     // 5. Register entities for factory (needed for level loading)
-    registerGameEntities(m_physicsManager.getWorld(), textures);
+    registerGameEntities(m_physicsManager.getWorld(), textures, m_entityManager);
 
     // 6. Setup surprise box manager
     m_surpriseBoxManager = std::make_unique<SurpriseBoxManager>(textures, window);
@@ -210,7 +209,7 @@ void GameSession::spawnFalconEnemy() {
     float spawnX = playerTransform->getPosition().x + WINDOW_WIDTH / 2.0f + 300.0f;
 
     auto enemy = std::make_unique<FalconEnemyEntity>(
-        g_nextEntityId++,
+        m_entityManager.generateId(),
         m_physicsManager.getWorld(),
         spawnX,
         0.0f,

--- a/src/Systems/Collision/GameCollisionSetup.cpp
+++ b/src/Systems/Collision/GameCollisionSetup.cpp
@@ -28,9 +28,6 @@
 #include <WellEntity.h>
 #include <GameSession.h>
 
-// For entity ID generation
-int g_nextEntityId = 1;
-
 void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
 
     // ===== Player vs Coin =====
@@ -506,17 +503,17 @@ void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
     );
 }
 
-void registerGameEntities(b2World& world, TextureManager& textures) {
+void registerGameEntities(b2World& world, TextureManager& textures, EntityManager& entityManager) {
     EntityFactory& factory = EntityFactory::instance();
 
     // Register Player
     factory.registerCreator("Player", [&](float x, float y) -> std::unique_ptr<Entity> {
-        return std::make_unique<PlayerEntity>(g_nextEntityId++, world, x, y, textures);
+        return std::make_unique<PlayerEntity>(entityManager.generateId(), world, x, y, textures);
         });
 
     // Register Coin
     factory.registerCreator("C", [&](float x, float y) -> std::unique_ptr<Entity> {
-        auto entity = std::make_unique<CoinEntity>(g_nextEntityId++);
+        auto entity = std::make_unique<CoinEntity>(entityManager.generateId());
 
         sf::Vector2f coinPosition(x + TILE_SIZE / 4.f, y + TILE_SIZE / 4.f);
         entity->addComponent<Transform>(coinPosition);
@@ -549,7 +546,7 @@ void registerGameEntities(b2World& world, TextureManager& textures) {
     // Register Gifts
     auto registerGift = [&](const std::string& levelChar, GiftEntity::GiftType type) {
         factory.registerCreator(levelChar, [&, type](float x, float y) -> std::unique_ptr<Entity> {
-            return std::make_unique<GiftEntity>(g_nextEntityId++, type, x, y, textures);
+            return std::make_unique<GiftEntity>(entityManager.generateId(), type, x, y, textures);
             });
         };
 
@@ -564,7 +561,7 @@ void registerGameEntities(b2World& world, TextureManager& textures) {
     // Register Ground Tiles
     auto registerGround = [&](const std::string& levelChar, TileType type) {
         factory.registerCreator(levelChar, [&, type](float x, float y) -> std::unique_ptr<Entity> {
-            return std::make_unique<GroundEntity>(g_nextEntityId++, type, world, x, y, textures);
+            return std::make_unique<GroundEntity>(entityManager.generateId(), type, world, x, y, textures);
             });
         };
 
@@ -576,25 +573,25 @@ void registerGameEntities(b2World& world, TextureManager& textures) {
 
     // Register remaining entity types
     factory.registerCreator("S", [&](float x, float y) -> std::unique_ptr<Entity> {
-        return std::make_unique<SeaEntity>(g_nextEntityId++, world, x, y, textures);
+        return std::make_unique<SeaEntity>(entityManager.generateId(), world, x, y, textures);
         });
 
     factory.registerCreator("X", [&](float x, float y) -> std::unique_ptr<Entity> {
-        return std::make_unique<FlagEntity>(g_nextEntityId++, world, x, y, textures);
+        return std::make_unique<FlagEntity>(entityManager.generateId(), world, x, y, textures);
         });
 
     factory.registerCreator("c", [&](float x, float y) -> std::unique_ptr<Entity> {
-        return std::make_unique<CactusEntity>(g_nextEntityId++, world, x, y, textures);
+        return std::make_unique<CactusEntity>(entityManager.generateId(), world, x, y, textures);
         });
 
     factory.registerCreator("B", [&](float x, float y) -> std::unique_ptr<Entity> {
-        return std::make_unique<BoxEntity>(g_nextEntityId++, world, x, y, textures);
+        return std::make_unique<BoxEntity>(entityManager.generateId(), world, x, y, textures);
         });
 
     // Register Square Enemy
     factory.registerCreator("z", [&](float x, float y) -> std::unique_ptr<Entity> {
         auto enemy = std::make_unique<SquareEnemyEntity>(
-            g_nextEntityId++,
+            entityManager.generateId(),
             world,
             x, y,
             textures,
@@ -606,18 +603,18 @@ void registerGameEntities(b2World& world, TextureManager& textures) {
 
     // Register Smart Enemy
     factory.registerCreator("Z", [&](float x, float y) -> std::unique_ptr<Entity> {
-        auto enemy = std::make_unique<SmartEnemyEntity>(g_nextEntityId++, world, x, y, textures);
+        auto enemy = std::make_unique<SmartEnemyEntity>(entityManager.generateId(), world, x, y, textures);
         return enemy;
         });
 
     // Register Falcon Enemy
     factory.registerCreator("F", [&](float x, float y) -> std::unique_ptr<Entity> {
-        auto enemy = std::make_unique<FalconEnemyEntity>(g_nextEntityId++, world, x, y, textures);
+        auto enemy = std::make_unique<FalconEnemyEntity>(entityManager.generateId(), world, x, y, textures);
         return enemy;
         });
     
     // Register Well
     factory.registerCreator("W", [&](float x, float y) -> std::unique_ptr<Entity> {
-        return std::make_unique<WellEntity>(g_nextEntityId++, world, x, y, textures);
+        return std::make_unique<WellEntity>(entityManager.generateId(), world, x, y, textures);
         });
 }

--- a/src/Systems/Managers/EntityManager.cpp
+++ b/src/Systems/Managers/EntityManager.cpp
@@ -60,3 +60,7 @@ void EntityManager::removeInactiveEntities() {
         }
     }
 }
+
+EntityManager::IdType EntityManager::generateId() {
+    return m_nextId++;
+}

--- a/src/Systems/Managers/GameLevelManager.cpp
+++ b/src/Systems/Managers/GameLevelManager.cpp
@@ -6,9 +6,10 @@
 #include <iostream>
 #include <PlayerEntity.h>
 #include "EntityFactory.h"
+#include "ResourcePaths.h"
 
 GameLevelManager::GameLevelManager() {
-    m_levelManager.addLevel("level1.txt");
+    m_levelManager.addLevel(ResourcePaths::LEVEL1);
 }
 
 void GameLevelManager::initialize(EntityManager& entityManager, PhysicsManager& physicsManager, TextureManager& textures) {
@@ -209,7 +210,7 @@ void GameLevelManager::onWellEntered(const WellEnteredEvent& event) {
     try {
         std::string targetLevel = event.targetLevel;
         if (targetLevel.empty()) {
-            targetLevel = "dark_level.txt";
+            targetLevel = ResourcePaths::DARK_LEVEL;
         }
         if (loadLevel(targetLevel)) {
         }

--- a/src/Systems/Managers/SurpriseBoxManager.cpp
+++ b/src/Systems/Managers/SurpriseBoxManager.cpp
@@ -13,8 +13,6 @@
 #include "GameEvents.h"
 #include <iostream>
 
-// For entity ID generation
-extern int g_nextEntityId;
 
 SurpriseBoxManager::SurpriseBoxManager(TextureManager& textures, sf::RenderWindow& window)
     : m_textures(textures)
@@ -136,7 +134,7 @@ void SurpriseBoxManager::spawnGiftEntity(SurpriseGiftType giftType, const sf::Ve
     try {
         // Create gift entity with physics so it falls
         auto giftEntity = std::make_unique<GiftEntity>(
-            g_nextEntityId++,
+            m_entityManager->generateId(),
             entityGiftType,
             position.x,
             position.y,

--- a/src/UI/GameplayScreen.cpp
+++ b/src/UI/GameplayScreen.cpp
@@ -6,6 +6,7 @@
 #include "UIObserver.h"
 #include "EventSystem.h"
 #include "GameEvents.h"
+#include "ResourcePaths.h"
 #include "PhysicsComponent.h"
 #include <iostream>
 #include <format>
@@ -208,7 +209,7 @@ void GameplayScreen::initializeGameSession(sf::RenderWindow& window) {
         m_gameSession->initialize(m_textures, window);
 
         // Load initial level using the level manager
-        m_gameSession->loadLevel("level1.txt");
+        m_gameSession->loadLevel(ResourcePaths::LEVEL1);
 
         // Initialize UI Observer
         initializeUIObserver();
@@ -234,7 +235,7 @@ void GameplayScreen::handleKeyboardInput(sf::Keyboard::Key keyCode) {
     switch (keyCode) {
     case sf::Keyboard::F1:
         // Reset to first level
-        m_gameSession->loadLevel("level1.txt");
+        m_gameSession->loadLevel(ResourcePaths::LEVEL1);
         std::cout << "[GameplayScreen] Reset to first level" << std::endl;
         break;
     case sf::Keyboard::F2:
@@ -857,7 +858,7 @@ void GameplayScreen::handleWellEnteredEvent(const WellEnteredEvent& event) {
     // Check for file existence
     std::string levelPath = event.targetLevel;
     if (levelPath.empty()) {
-        levelPath = "dark_level.txt";
+        levelPath = ResourcePaths::DARK_LEVEL;
         std::cout << "[GameplayScreen] Using default dark level" << std::endl;
     }
 


### PR DESCRIPTION
## Summary
- centralize unique entity IDs inside `EntityManager`
- remove global `g_nextEntityId`
- update factories and systems to obtain IDs from `EntityManager`
- add `ResourcePaths.h` and replace hard coded level names

## Testing
- `cmake --preset x64-Debug` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6874444b26ec83269237a5aadfdbe6fb