### PR TITLE
Reset score & timer on death

### DIFF
--- a/include/UI/UIOverlay.h
+++ b/include/UI/UIOverlay.h
@@ -10,6 +10,9 @@ public:
     void update(int score, int lives);
     void draw(sf::RenderWindow& window);
 
+    /// Reset the in-game timer
+    void reset();
+
     bool isPaused() const;
 
 private:

--- a/src/UI/GameplayScreen.cpp
+++ b/src/UI/GameplayScreen.cpp
@@ -539,6 +539,14 @@ void GameplayScreen::checkGameOverCondition(PlayerEntity* player) {
     if (health && !health->isAlive() && !m_showingGameOver) {
         m_showingGameOver = true;
 
+        if (auto* scoreManager = player->getScoreManager()) {
+            scoreManager->resetScore();
+        }
+
+        if (m_ui) {
+            m_ui->reset();
+        }
+
         // Position the game over text
         sf::FloatRect bounds = m_gameOverText.getLocalBounds();
         m_gameOverText.setOrigin(bounds.width / 2.0f, bounds.height / 2.0f);

--- a/src/UI/UIOverlay.cpp
+++ b/src/UI/UIOverlay.cpp
@@ -66,3 +66,7 @@ void UIOverlay::draw(sf::RenderWindow& window) {
 bool UIOverlay::isPaused() const {
     return m_paused;
 }
+
+void UIOverlay::reset() {
+    m_timer.restart();
+}


### PR DESCRIPTION
## Summary
- add `reset()` function to `UIOverlay`
- restart timer and reset score when player loses all lives

## Testing
- `cmake -B build -S .` *(fails: Could not find package SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68744d4d5f5c8326ae93971e07549809