### PR TITLE
Refactor winning screen

### DIFF
--- a/include/Game/GameSession.h
+++ b/include/Game/GameSession.h
@@ -28,8 +28,7 @@ public:
     ~GameSession();
     DarkLevelSystem& getDarkLevelSystem() { return m_darkLevelSystem; }
 
-    void showWinningScreen();
-    sf::RenderWindow& getWindow();  
+    sf::RenderWindow& getWindow();
 
     void initialize(TextureManager& textures, sf::RenderWindow& window);
     void update(float deltaTime);

--- a/include/UI/WinningScreen.h
+++ b/include/UI/WinningScreen.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <string>
+
+/**
+ * @brief Dedicated screen for displaying the winning image.
+ *        This class handles only the winning screen logic
+ *        to keep GameSession free from UI responsibilities.
+ */
+class WinningScreen {
+public:
+    explicit WinningScreen(const std::string& textureFile = "winning.png");
+    void show(sf::RenderWindow& window);
+
+private:
+    std::string m_textureFile;
+};

--- a/src/Game/GameSession.cpp
+++ b/src/Game/GameSession.cpp
@@ -218,31 +218,6 @@ void GameSession::spawnFalconEnemy() {
     spawnEntity(std::move(enemy));
 }
 
-void GameSession::showWinningScreen() {
-    sf::Texture texture;
-    if (!texture.loadFromFile("winning.png")) {
-        std::cerr << "[ERROR] Could not load winning.png" << std::endl;
-        return;
-    }
-
-    sf::Sprite sprite(texture);
-
-    sf::RenderWindow& window = getWindow();  
-    while (window.isOpen()) {
-        sf::Event event;
-        while (window.pollEvent(event)) {
-            if (event.type == sf::Event::Closed ||
-                (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape)) {
-                window.close();
-            }
-        }
-
-        window.clear();
-        window.draw(sprite);
-        window.display();
-    }
-}
-
 sf::RenderWindow& GameSession::getWindow() {
     return *m_window;
 }

--- a/src/Systems/Collision/GameCollisionSetup.cpp
+++ b/src/Systems/Collision/GameCollisionSetup.cpp
@@ -27,6 +27,7 @@
 #include <SquareEnemyEntity.h>
 #include <WellEntity.h>
 #include <GameSession.h>
+#include <WinningScreen.h>
 
 void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
 
@@ -176,9 +177,10 @@ void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
 
             flag.setCompleted(true);
 
-            // عرض صورة الفوز
+            // Display winning screen using dedicated class
             if (g_currentSession) {
-                g_currentSession->showWinningScreen();  // ← تأكد أن هذه الدالة موجودة
+                WinningScreen screen;
+                screen.show(g_currentSession->getWindow());
             }
 
             // إضافة نقاط المكافأة

--- a/src/UI/WinningScreen.cpp
+++ b/src/UI/WinningScreen.cpp
@@ -1,0 +1,29 @@
+#include "WinningScreen.h"
+#include <iostream>
+
+WinningScreen::WinningScreen(const std::string& textureFile)
+    : m_textureFile(textureFile) {}
+
+void WinningScreen::show(sf::RenderWindow& window) {
+    sf::Texture texture;
+    if (!texture.loadFromFile(m_textureFile)) {
+        std::cerr << "[ERROR] Could not load " << m_textureFile << std::endl;
+        return;
+    }
+
+    sf::Sprite sprite(texture);
+
+    while (window.isOpen()) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed ||
+                (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape)) {
+                window.close();
+            }
+        }
+
+        window.clear();
+        window.draw(sprite);
+        window.display();
+    }
+}


### PR DESCRIPTION
## Summary
- extract winning screen display into new `WinningScreen` class
- remove `showWinningScreen` from `GameSession`
- use `WinningScreen` in collision handler for the flag

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68744ffa87b08326b32019f8fcb119c4