### PR TITLE
Fix screen transitions

### DIFF
--- a/include/Core/IScreen.h
+++ b/include/Core/IScreen.h
@@ -19,4 +19,8 @@ public:
 
     // Draw everything to screen (sprites, text, UI)
     virtual void render(sf::RenderWindow& window) = 0;
+
+    // Optional lifecycle hooks
+    virtual void onEnter() {}
+    virtual void onExit() {}
 };

--- a/include/Screens/GameplayScreen.h
+++ b/include/Screens/GameplayScreen.h
@@ -35,6 +35,10 @@ public:
     void update(float deltaTime) override;
     void render(sf::RenderWindow& window) override;
 
+    // Lifecycle hooks
+    void onEnter() override {}
+    void onExit() override {}
+
 private:
     // Core systems
     std::unique_ptr<GameSession> m_gameSession;

--- a/include/Screens/MenuScreen.h
+++ b/include/Screens/MenuScreen.h
@@ -22,8 +22,8 @@ public:
     void render(sf::RenderWindow& window) override;
 
     // Screen lifecycle
-    void onEnter();
-    void onExit();
+    void onEnter() override;
+    void onExit() override;
 
     // Configuration
     void setAnimationSpeed(float speed);

--- a/src/Core/ScreenManager.cpp
+++ b/src/Core/ScreenManager.cpp
@@ -6,8 +6,19 @@ void ScreenManager::registerScreen(ScreenType type, std::function<std::unique_pt
 
 void ScreenManager::changeScreen(ScreenType type) {
     auto it = m_creators.find(type);
-    if (it != m_creators.end()) {
-        m_currentScreen = it->second();
+    if (it == m_creators.end()) {
+        return;
+    }
+
+    if (m_currentScreen) {
+        m_currentScreen->onExit();
+    }
+
+    m_currentScreen.reset();
+    m_currentScreen = it->second();
+
+    if (m_currentScreen) {
+        m_currentScreen->onEnter();
     }
 }
 


### PR DESCRIPTION
## Summary
- add lifecycle hooks to `IScreen`
- ensure `ScreenManager` calls `onExit` and `onEnter`
- update menu and gameplay screens to override lifecycle hooks

## Testing
- `cmake ..` *(fails: FindSFML.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755d2d2fb48326a2c55b50678b0f92