### PR TITLE
Fix event system static lifetime

### DIFF
--- a/src/Systems/Events/EventSystem.cpp
+++ b/src/Systems/Events/EventSystem.cpp
@@ -2,8 +2,8 @@
 #include "EventSystem.h"
 
 EventSystem& EventSystem::getInstance() {
-    static EventSystem instance;
-    return instance;
+    static EventSystem* instance = new EventSystem();
+    return *instance;
 }
 
 void EventSystem::clear() {


### PR DESCRIPTION
## Summary
- fix destruction order issue by leaking EventSystem

## Testing
- `cmake -S . -B build` *(fails: could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_6875601a6a8083268b8c419bd768ba6a