### PR TITLE
Fix use-after-free when winning

### DIFF
--- a/src/Systems/Collision/GameCollisionSetup.cpp
+++ b/src/Systems/Collision/GameCollisionSetup.cpp
@@ -182,15 +182,16 @@ void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
 
             flag.setCompleted(true);
 
+            // Award score before the session potentially ends
+            if (auto* scoreManager = player.getScoreManager()) {
+                scoreManager->addScore(500);
+            }
+
             // Display winning screen then return to main menu
             if (g_currentSession) {
                 WinningScreen screen;
                 screen.show(g_currentSession->getWindow());
                 AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
-            }
-
-            if (auto* scoreManager = player.getScoreManager()) {
-                scoreManager->addScore(500);
             }
         }
     );


### PR DESCRIPTION
## Summary
- prevent dereferencing deleted `PlayerEntity` during flag collision

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6875a1e9063c8326b82e3d6a02a40d76