### PR TITLE
Fix use-after-free by deferring screen changes

### DIFF
--- a/include/Core/ScreenManager.h
+++ b/include/Core/ScreenManager.h
@@ -16,8 +16,11 @@ public:
     // Register a screen factory function for a given screen type
     void registerScreen(ScreenType type, std::function<std::unique_ptr<IScreen>()> creator);
 
-    // Change to a different screen
+    // Change to a different screen immediately
     void changeScreen(ScreenType type);
+
+    // Request a screen change to be processed after the current update cycle
+    void requestScreenChange(ScreenType type);
 
     // Handle SFML events for the current screen
     void handleEvents(sf::RenderWindow& window);
@@ -34,4 +37,7 @@ public:
 private:
     std::unordered_map<ScreenType, std::function<std::unique_ptr<IScreen>()>> m_creators;
     std::unique_ptr<IScreen> m_currentScreen;
+
+    bool m_screenChangeRequested = false;
+    ScreenType m_nextScreen = ScreenType::MENU;
 };

--- a/src/Application/GameInitializer.cpp
+++ b/src/Application/GameInitializer.cpp
@@ -102,7 +102,7 @@ void GameInitializer::registerAllScreens() {
     try {
         Logger::log("Registering all screens...");
         registerScreenFactories();
-        AppContext::instance().screenManager().changeScreen(ScreenType::LOADING);
+        AppContext::instance().screenManager().requestScreenChange(ScreenType::LOADING);
         Logger::log("All screens registered successfully");
     }
     catch (const std::exception& e) {

--- a/src/Commands/ChangeScreenCommand.cpp
+++ b/src/Commands/ChangeScreenCommand.cpp
@@ -17,7 +17,7 @@ ChangeScreenCommand::ChangeScreenCommand(ScreenType targetScreen, ScreenType pre
 void ChangeScreenCommand::execute() {
     try {
         // Use AppContext singleton to access screen manager and change screen
-        AppContext::instance().screenManager().changeScreen(m_targetScreen);
+        AppContext::instance().screenManager().requestScreenChange(m_targetScreen);
     }
     catch (const std::exception& e) {
         // Handle any errors that occur during screen change
@@ -32,7 +32,7 @@ void ChangeScreenCommand::execute() {
 void ChangeScreenCommand::undo() {
     try {
         // Navigate back to the previous screen
-        AppContext::instance().screenManager().changeScreen(m_previousScreen);
+        AppContext::instance().screenManager().requestScreenChange(m_previousScreen);
     }
     catch (const std::exception& e) {
         // Handle any errors that occur during undo operation

--- a/src/Commands/EscapeKeyCommand.cpp
+++ b/src/Commands/EscapeKeyCommand.cpp
@@ -8,7 +8,7 @@ EscapeKeyCommand::EscapeKeyCommand(ScreenType currentScreen, ScreenType targetSc
 void EscapeKeyCommand::execute() {
     try {
         // Get screen manager
-        AppContext::instance().screenManager().changeScreen(m_targetScreen);
+        AppContext::instance().screenManager().requestScreenChange(m_targetScreen);
 
         // Mark as executed
         m_hasExecuted = true;
@@ -26,7 +26,7 @@ void EscapeKeyCommand::undo() {
     }
 
     try {
-        AppContext::instance().screenManager().changeScreen(m_currentScreen);
+        AppContext::instance().screenManager().requestScreenChange(m_currentScreen);
     }
     catch (const std::exception& e) {
         std::cout << "EscapeKeyCommand: Failed to undo - " << e.what() << std::endl;

--- a/src/Core/ScreenManager.cpp
+++ b/src/Core/ScreenManager.cpp
@@ -22,15 +22,30 @@ void ScreenManager::changeScreen(ScreenType type) {
     }
 }
 
+void ScreenManager::requestScreenChange(ScreenType type) {
+    m_screenChangeRequested = true;
+    m_nextScreen = type;
+}
+
 void ScreenManager::handleEvents(sf::RenderWindow& window) {
     if (m_currentScreen) {
         m_currentScreen->handleEvents(window);
+    }
+
+    if (m_screenChangeRequested) {
+        changeScreen(m_nextScreen);
+        m_screenChangeRequested = false;
     }
 }
 
 void ScreenManager::update(float deltaTime) {
     if (m_currentScreen) {
         m_currentScreen->update(deltaTime);
+    }
+
+    if (m_screenChangeRequested) {
+        changeScreen(m_nextScreen);
+        m_screenChangeRequested = false;
     }
 }
 

--- a/src/Screens/AboutScreen.cpp
+++ b/src/Screens/AboutScreen.cpp
@@ -33,7 +33,7 @@ void AboutScreen::handleEvents(sf::RenderWindow& window) {
 
         if (event.type == sf::Event::KeyPressed) {
             if (event.key.code == sf::Keyboard::Escape) {
-                AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
+                AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
             }
         }
     }

--- a/src/Screens/GameplayScreen.cpp
+++ b/src/Screens/GameplayScreen.cpp
@@ -563,7 +563,7 @@ void GameplayScreen::checkGameOverCondition(PlayerEntity* player) {
         if (m_window) {
             GameOverScreen screen;
             screen.show(*m_window);
-            AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
+            AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
         }
     }
 }

--- a/src/Screens/HelpScreen.cpp
+++ b/src/Screens/HelpScreen.cpp
@@ -30,7 +30,7 @@ void HelpScreen::handleEvents(sf::RenderWindow& window) {
 
         if (event.type == sf::Event::KeyPressed) {
             if (event.key.code == sf::Keyboard::Escape) {
-                AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
+                AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
             }
         }
     }

--- a/src/Screens/LoadingScreen.cpp
+++ b/src/Screens/LoadingScreen.cpp
@@ -47,7 +47,7 @@ void LoadingScreen::update(float deltaTime) {
 
     if (m_progress >= 1.0f && !m_finished) {
         m_finished = true;
-        AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
+        AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
     }
 }
 

--- a/src/Screens/SettingsScreen.cpp
+++ b/src/Screens/SettingsScreen.cpp
@@ -43,7 +43,7 @@ void SettingsScreen::handleEvents(sf::RenderWindow& window) {
         if (event.type == sf::Event::KeyPressed && m_commandHandler) {
             bool shouldExit = m_commandHandler->handleKeyboardInput(event);
             if (shouldExit) {
-                AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
+                AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
                 return;
             }
         }

--- a/src/Systems/Collision/GameCollisionSetup.cpp
+++ b/src/Systems/Collision/GameCollisionSetup.cpp
@@ -191,7 +191,7 @@ void setupGameCollisionHandlers(MultiMethodCollisionSystem& collisionSystem) {
             if (g_currentSession) {
                 WinningScreen screen;
                 screen.show(g_currentSession->getWindow());
-                AppContext::instance().screenManager().changeScreen(ScreenType::MENU);
+                AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
             }
         }
     );


### PR DESCRIPTION
## Summary
- add deferred screen-change support in `ScreenManager`
- switch all screen transitions to request-based API
- update winning/game over logic to use deferred requests

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6875a3cd8d348326a0431ea24e6477b7