### PR TITLE
Change Escape key behavior in gameplay

### DIFF
--- a/src/Screens/GameplayScreen.cpp
+++ b/src/Screens/GameplayScreen.cpp
@@ -260,9 +260,8 @@ void GameplayScreen::handleKeyboardInput(sf::Keyboard::Key keyCode) {
         }
         break;
     case sf::Keyboard::Escape:
-        if (m_window) {
-            m_window->close();
-        }
+        // Return to the main menu rather than closing the window
+        AppContext::instance().screenManager().requestScreenChange(ScreenType::MENU);
         break;
     default:
         break;


### PR DESCRIPTION
## Summary
- change Escape key in GameplayScreen to return to the menu instead of closing the window

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_687689d0a8c08326a58fb34886a11dd7