### PR TITLE
Centralize image loading

### DIFF
--- a/include/Application/GameInitializer.h
+++ b/include/Application/GameInitializer.h
@@ -62,6 +62,16 @@ private:
     void loadDefaultAudioFiles();
 
     /**
+     * @brief Preloads all textures used throughout the game.
+     */
+    void loadDefaultTextures();
+
+    /**
+     * @brief Preloads fonts required by the UI system.
+     */
+    void loadDefaultFonts();
+
+    /**
      * @brief Saves current audio volume levels as defaults.
      */
     void setDefaultAudioVolumes();

--- a/src/Application/GameInitializer.cpp
+++ b/src/Application/GameInitializer.cpp
@@ -1,3 +1,4 @@
+#include <vector>
 ﻿#include <Application/GameInitializer.h>
 #include <Services/Logger.h>
 #include <Screens/GameplayScreen.h>
@@ -74,6 +75,34 @@ void GameInitializer::setDefaultAudioVolumes() {
     AudioSettingsManager::save(settings);
     Logger::log("Set default audio volumes");
 }
+
+void GameInitializer::loadDefaultTextures() {
+    auto& textures = AppContext::instance().textures();
+    const std::vector<std::string> files = {
+        "AboutButton.png", "About_UsScreen.png", "ExitButtonEnglish.png",
+        "GameOver.png", "HelpButtonEnglish.png", "HelpScreen.png",
+        "LoadingScreen.png", "MenuScreen.png", "SettingsButtonEnglish.png",
+        "SettingsScreen.png", "StartButtonEnglish.png", "Winning.png",
+        "warningScreen.png", "BoxBackground.png", "Bullet.png", "Cactus.png",
+        "CloseBox.png", "Coin.png", "Edge.png", "FalconEnemy.png",
+        "FalconEnemy2.png", "HeadwindStormGift.png", "LifeHeartGift.png",
+        "MagneticBall.png", "MagneticGift.png", "NormalBall.png", "OpenBox.png",
+        "ProtectiveShieldGift.png", "RareCoinGift.png", "ReverseMovementGift.png",
+        "SpeedGift.png", "SquareEnemy.png", "SquareEnemy2.png",
+        "TransparentBall.png", "redFlag.png", "shootEnemy1.png",
+        "shootEnemy2.png", "well.png", "wooden_box.png", "Sea.png",
+        "left.png", "middle.png", "right.png", "ground.png",
+        "backGroundGame.jpeg"
+    };
+    for (const auto& f : files) {
+        textures.preload(f);
+    }
+}
+
+void GameInitializer::loadDefaultFonts() {
+    auto& fonts = AppContext::instance().fonts();
+    fonts.preload("arial.ttf");
+}
 //-------------------------------------------------------------------------------------
 void GameInitializer::initializeResourceSystem() {
     try {
@@ -82,6 +111,9 @@ void GameInitializer::initializeResourceSystem() {
         auto& textures = AppContext::instance().textures();
         auto& fonts = AppContext::instance().fonts();
         auto& sounds = AppContext::instance().sounds();
+
+        loadDefaultTextures();
+        loadDefaultFonts();
 
         Logger::log("Resource system initialized successfully");
     }

--- a/src/Screens/GameplayScreen.cpp
+++ b/src/Screens/GameplayScreen.cpp
@@ -69,9 +69,12 @@ void GameplayScreen::initializeComponents() {
         m_ui = std::make_unique<UIOverlay>(WINDOW_WIDTH);
         m_darkLevelSystem = std::make_unique<DarkLevelSystem>();
 
-        // Load font for UI
-        if (!m_font.loadFromFile("arial.ttf")) {
-            std::cerr << "[WARNING] Failed to load font" << std::endl;
+        // Load font for UI from centralized resource manager
+        try {
+            m_font = AppContext::instance().getFont("arial.ttf");
+        }
+        catch (const std::exception& e) {
+            std::cerr << "[WARNING] Failed to load font: " << e.what() << std::endl;
         }
 
         // Initialize camera

--- a/src/Systems/Rendering/BackgroundRenderer.cpp
+++ b/src/Systems/Rendering/BackgroundRenderer.cpp
@@ -2,11 +2,8 @@
 #include "Constants.h"
 #include <stdexcept>
 
-BackgroundRenderer::BackgroundRenderer(TextureManager&) {
-    if (!m_backgroundTexture.loadFromFile("backGroundGame.jpeg")) {
-        throw std::runtime_error("Failed to load background image.");
-    }
-
+BackgroundRenderer::BackgroundRenderer(TextureManager& textures) {
+    m_backgroundTexture = textures.getResource("backGroundGame.jpeg");
     setupBackground();
 }
 

--- a/src/UI/GameOverScreen.cpp
+++ b/src/UI/GameOverScreen.cpp
@@ -1,5 +1,6 @@
 #include "GameOverScreen.h"
 #include "../Core/AudioManager.h"
+#include <Application/AppContext.h>
 #include <iostream>
 
 GameOverScreen::GameOverScreen(const std::string& textureFile)
@@ -9,12 +10,7 @@ void GameOverScreen::show(sf::RenderWindow& window) {
     AudioManager::instance().pauseMusic();
     AudioManager::instance().playSound("gameover");
 
-    sf::Texture texture;
-    if (!texture.loadFromFile(m_textureFile)) {
-        std::cerr << "[ERROR] Could not load " << m_textureFile << std::endl;
-        return;
-    }
-
+    sf::Texture& texture = AppContext::instance().getTexture(m_textureFile);
     sf::Sprite sprite(texture);
     bool running = true;
 

--- a/src/UI/SurpriseBoxScreen.cpp
+++ b/src/UI/SurpriseBoxScreen.cpp
@@ -2,6 +2,7 @@
 #include "ResourceManager.h"
 #include "Exceptions/GameExceptions.h"
 #include "Exceptions/Logger.h"
+#include <Application/AppContext.h>
 #include <iostream>
 #include <cmath>
 #include <sstream>
@@ -82,11 +83,9 @@ SurpriseBoxScreen::SurpriseBoxScreen(sf::RenderWindow& window, TextureManagerTyp
     m_fallbackBox.setOutlineThickness(3.0f);
     m_fallbackBox.setOutlineColor(sf::Color(101, 67, 33)); // Darker brown
 
-    // Load font
+    // Load font from centralized resource manager
     try {
-        if (!m_font.loadFromFile("arial.ttf")) {
-            throw GameExceptions::ResourceLoadException("arial.ttf", "loadFromFile returned false");
-        }
+        m_font = AppContext::instance().getFont("arial.ttf");
     }
     catch (const std::exception& ex) {
         GameExceptions::getLogger().logException(ex);

--- a/src/UI/UIOverlay.cpp
+++ b/src/UI/UIOverlay.cpp
@@ -1,10 +1,9 @@
 ﻿#include "UIOverlay.h"
+#include <Application/AppContext.h>
 #include <sstream>
 
 UIOverlay::UIOverlay(float windowWidth) {
-    if (!m_font.loadFromFile("arial.ttf")) {
-        throw std::runtime_error("Failed to load font");
-    }
+    m_font = AppContext::instance().getFont("arial.ttf");
 
     m_scoreText.setFont(m_font);
     m_livesText.setFont(m_font);

--- a/src/UI/WinningScreen.cpp
+++ b/src/UI/WinningScreen.cpp
@@ -1,6 +1,7 @@
 #include "WinningScreen.h"
 #include <iostream>
 #include "../Core/AudioManager.h"
+#include <Application/AppContext.h>
 
 WinningScreen::WinningScreen(const std::string& textureFile)
     : m_textureFile(textureFile) {
@@ -10,12 +11,7 @@ void WinningScreen::show(sf::RenderWindow& window) {
     AudioManager::instance().stopAllSounds();
     AudioManager::instance().playSound("win");
 
-    sf::Texture texture;
-    if (!texture.loadFromFile(m_textureFile)) {
-        std::cerr << "[ERROR] Could not load " << m_textureFile << std::endl;
-        return;
-    }
-
+    sf::Texture& texture = AppContext::instance().getTexture(m_textureFile);
     sf::Sprite sprite(texture);
 
     bool running = true;


### PR DESCRIPTION
## Summary
- preload textures and fonts in `GameInitializer`
- fetch textures from `AppContext` in UI screens
- use centralized font in gameplay and UI classes
- pull background texture from texture manager

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68769699a9a88326962be783fe1d6098