### PR TITLE
Update falcon spawn time

### DIFF
--- a/src/Game/GameSession.cpp
+++ b/src/Game/GameSession.cpp
@@ -188,7 +188,7 @@ void GameSession::updateFalconSpawner(float deltaTime) {
         return;
 
     m_falconSpawnTimer += deltaTime;
-    if (m_falconSpawnTimer >= 30.0f) {
+    if (m_falconSpawnTimer >= 15.0f) {
         spawnFalconEnemy();
         m_falconSpawned = true;
     }


### PR DESCRIPTION
## Summary
- reduce spawn delay for the falcon enemy from 30s to 15s

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6876b3f66ac88326a4f97ffe797793cb