### PR TITLE
Show help screen before gameplay

### DIFF
--- a/include/Screens/HelpScreen.h
+++ b/include/Screens/HelpScreen.h
@@ -14,4 +14,9 @@ public:
 private:
     sf::Texture m_backgroundTexture;
     sf::Sprite m_backgroundSprite;
+
+    // Timer to control how long the help screen is displayed
+    float m_elapsedTime = 0.0f;
+    const float m_displayDuration = 3.0f; // seconds
+    bool m_startRequested = false;
 };

--- a/src/Screens/HelpScreen.cpp
+++ b/src/Screens/HelpScreen.cpp
@@ -38,6 +38,12 @@ void HelpScreen::handleEvents(sf::RenderWindow& window) {
 }
 //-------------------------------------------------------------------------------------
 void HelpScreen::update(float deltaTime) {
+    m_elapsedTime += deltaTime;
+
+    if (!m_startRequested && m_elapsedTime >= m_displayDuration) {
+        m_startRequested = true;
+        AppContext::instance().screenManager().requestScreenChange(ScreenType::PLAY);
+    }
 }
 //-------------------------------------------------------------------------------------
 void HelpScreen::render(sf::RenderWindow& window) {

--- a/src/UI/MenuButtonObserver.cpp
+++ b/src/UI/MenuButtonObserver.cpp
@@ -34,7 +34,8 @@ void MenuButtonObserver::handleStartButton() {
     std::cout << "MenuButtonObserver: Handling Start Game..." << std::endl;
 
     ScreenType currentScreen = getCurrentScreen();
-    auto command = std::make_unique<ChangeScreenCommand>(ScreenType::PLAY, currentScreen);
+    // Show the help screen before starting the actual gameplay
+    auto command = std::make_unique<ChangeScreenCommand>(ScreenType::HELP, currentScreen);
     m_commandInvoker.execute(std::move(command));
 }
 //-------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- display HelpScreen while the game loads
- switch to the Play screen once the timer expires
- change Start button to show the Help screen first

## Testing
- `cmake --preset x64-Debug` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6876b620f86483268a151c6c632f5019