### PR TITLE
Add help overlay at game start

### DIFF
--- a/include/Screens/GameplayScreen.h
+++ b/include/Screens/GameplayScreen.h
@@ -74,6 +74,12 @@ private:
     float m_messageDuration = 3.0f;
     bool m_levelTransitionInProgress = false;  // Added for safe level transitions
     bool m_playerValid = false;                // Added for player validation
+
+    // Help overlay
+    bool m_showHelpImage = true;
+    float m_helpTimer = 0.0f;
+    const float m_helpDuration = 3.0f;
+    sf::Sprite m_helpSprite;
     
     // Initialization methods
     void initializeComponents();

--- a/src/Screens/GameplayScreen.cpp
+++ b/src/Screens/GameplayScreen.cpp
@@ -86,6 +86,22 @@ void GameplayScreen::initializeComponents() {
         // Try to load Game Over sprite with proper exception handling
         loadGameOverSprite();
 
+        // Load help overlay
+        try {
+            m_helpSprite.setTexture(m_textures.getResource("HelpScreen.png"));
+            sf::Vector2u texSize = m_helpSprite.getTexture()->getSize();
+            if (texSize.x > 0 && texSize.y > 0) {
+                float scaleX = WINDOW_WIDTH / static_cast<float>(texSize.x);
+                float scaleY = WINDOW_HEIGHT / static_cast<float>(texSize.y);
+                m_helpSprite.setScale(scaleX, scaleY);
+            }
+            m_showHelpImage = true;
+            m_helpTimer = 0.0f;
+        } catch (const std::exception& e) {
+            std::cerr << "[WARNING] Could not load HelpScreen.png: " << e.what() << std::endl;
+            m_showHelpImage = false;
+        }
+
         std::cout << "[GameplayScreen] Components initialized with SRP GameSession" << std::endl;
     }
     catch (const std::exception& e) {
@@ -274,6 +290,14 @@ void GameplayScreen::handleKeyboardInput(sf::Keyboard::Key keyCode) {
  * @param deltaTime Time elapsed since last frame
  */
 void GameplayScreen::update(float deltaTime) {
+
+    if (m_showHelpImage) {
+        m_helpTimer += deltaTime;
+        if (m_helpTimer >= m_helpDuration) {
+            m_showHelpImage = false;
+        }
+        return;
+    }
 
     // Check for level change requests from well
     if (handleWellLevelChangeRequests()) {
@@ -644,6 +668,10 @@ void GameplayScreen::render(sf::RenderWindow& window) {
 
     // Render appropriate messages based on game state
     renderGameMessages(window);
+
+    if (m_showHelpImage) {
+        window.draw(m_helpSprite);
+    }
 }
 
 /**

--- a/src/UI/MenuButtonObserver.cpp
+++ b/src/UI/MenuButtonObserver.cpp
@@ -34,8 +34,7 @@ void MenuButtonObserver::handleStartButton() {
     std::cout << "MenuButtonObserver: Handling Start Game..." << std::endl;
 
     ScreenType currentScreen = getCurrentScreen();
-    // Show the help screen before starting the actual gameplay
-    auto command = std::make_unique<ChangeScreenCommand>(ScreenType::HELP, currentScreen);
+    auto command = std::make_unique<ChangeScreenCommand>(ScreenType::PLAY, currentScreen);
     m_commandInvoker.execute(std::move(command));
 }
 //-------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- start game directly from menu without going through Help screen
- show the help image when the gameplay screen initializes

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6876b9290c0883268ce8720206dd3122